### PR TITLE
Add Foreach Function

### DIFF
--- a/conff/data/malformed_foreach_01.yml
+++ b/conff/data/malformed_foreach_01.yml
@@ -1,0 +1,7 @@
+# malformed foreach sections
+test:
+  F.foreach:
+    template:
+      '"test%i"%loop.index': 
+        value: loop.value
+        length: loop.length

--- a/conff/data/malformed_foreach_02.yml
+++ b/conff/data/malformed_foreach_02.yml
@@ -1,0 +1,4 @@
+test:
+  F.foreach:
+    values: F.arange(0, 6, 4)
+    template: 'notadict'

--- a/conff/data/test_config_02.yml
+++ b/conff/data/test_config_02.yml
@@ -62,3 +62,26 @@ test_14:
       test_13_6_2:
         test_13_6_2_1: 1
         test_13_6_2_2: 2
+# test 15: foreach with linspace
+test_15:
+  F.foreach:
+    values: F.linspace(0, 6, 3)
+    template:
+      '"test%i"%loop.index': 
+        value: loop.value
+        length: loop.length
+# test 16: foreach with arange
+test_16:
+  F.foreach:
+    values: F.arange(0, 6, 3)
+    template:
+      '"test%i"%loop.index': 
+        value: loop.value
+        length: loop.length
+test_17:
+  F.foreach:
+    values: F.arange(0, 6, 4)
+    template:
+      '"test%i"%loop.index': 
+        value: loop.value
+        length: loop.length

--- a/conff/test.py
+++ b/conff/test.py
@@ -29,8 +29,6 @@ class ConffTestCase(TestCase):
         errs = []
         data = conff.load(fs_path=fs_path, params={'ekey': key}, errors=errs)
         data = data if data else {}
-        if errs:
-            print("Error list: ", errs)
         # test simple types
         self.assertEqual(data.get('test_1'), 'test_1')
         self.assertEqual(data.get('test_2'), 2)
@@ -77,9 +75,18 @@ class ConffTestCase(TestCase):
         data_test_17 = {'test0': {'value': 0, 'length': 2},
                         'test1': {'value': 4, 'length': 2}}
         self.assertDictEqual(data.get('test_17'), data_test_17)
+        # test foreach exceptions
 
     def test_error_load_yaml(self):
         fs_path = self.get_test_data_path('test_config_03.yml')
+        data = conff.load(fs_path=fs_path)
+        self.assertIsNone(data)
+
+    def test_error_foreach(self):
+        fs_path = self.get_test_data_path('malformed_foreach_01.yml')
+        data = conff.load(fs_path=fs_path)
+        self.assertIsNone(data)
+        fs_path = self.get_test_data_path('malformed_foreach_02.yml')
         data = conff.load(fs_path=fs_path)
         self.assertIsNone(data)
 

--- a/conff/test.py
+++ b/conff/test.py
@@ -26,8 +26,11 @@ class ConffTestCase(TestCase):
     def test_complex_load_yml(self):
         fs_path = self.get_test_data_path('test_config_02.yml')
         key = Fernet.generate_key()
-        data = conff.load(fs_path=fs_path, params={'ekey': key})
+        errs = []
+        data = conff.load(fs_path=fs_path, params={'ekey': key}, errors=errs)
         data = data if data else {}
+        if errs:
+            print("Error list: ", errs)
         # test simple types
         self.assertEqual(data.get('test_1'), 'test_1')
         self.assertEqual(data.get('test_2'), 2)
@@ -62,6 +65,18 @@ class ConffTestCase(TestCase):
                         'test_13_6': {'test_13_6_1': 1, 'test_13_6_2': {'test_13_6_2_1': 1, 'test_13_6_2_2': 2}},
                         'test_13_4': 4}
         self.assertDictEqual(data.get('test_14'), data_test_14)
+        # test foreach with linspace
+        data_test_15 = {'test0': {'value': 0, 'length': 3},
+                        'test1': {'value': 3, 'length': 3},
+                        'test2': {'value': 6, 'length': 3}}
+        self.assertDictEqual(data.get('test_15'), data_test_15)
+        # test foreach with arange. Should get same result as above
+        data_test_16 = data_test_15
+        self.assertDictEqual(data.get('test_16'), data_test_16)
+        # test foreach with arange. Testing behavior of arange
+        data_test_17 = {'test0': {'value': 0, 'length': 2},
+                        'test1': {'value': 4, 'length': 2}}
+        self.assertDictEqual(data.get('test_17'), data_test_17)
 
     def test_error_load_yaml(self):
         fs_path = self.get_test_data_path('test_config_03.yml')


### PR DESCRIPTION
Added a F.foreach function similar to the F.extend and F.update functions. 

If there is a key in the configuration that matches "F.foreach", a special function is called that modifies the structure of the dictionary via a parameterized for loop. It was a pretty simple addition, so looking at the diff should make it clear what this new function does. I added it because this library is really nice, but I needed this function to cover 100% of my use cases (for now). 

I created a separate branch for these modifications, so we can discuss any changes you'd like me to make (in the event you even want to merge this) without the history on my master branch getting all cluttered. Please let me know how you like me to merge/rebase onto my master branch. 

I'd be happy to continue contributing! I'll definitely continue to use this in one of my projects, so I have a vested interest in ongoing maintenance. 